### PR TITLE
Fix Google Sign-In state reset on page navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,9 +431,7 @@
         // Initialize authentication on page load
         window.addEventListener('DOMContentLoaded', async () => {
             try {
-                await initAuth();
-
-                // Set up auth state callback
+                // Set up auth state callback BEFORE initAuth
                 onAuthStateChanged((user) => {
                     if (user) {
                         showSignedInUI(user);
@@ -442,8 +440,12 @@
                     }
                 });
 
-                // Initialize Google Sign-In button
-                await initGoogleSignIn('googleSignInButton');
+                await initAuth();
+
+                // Initialize Google Sign-In button only if not already signed in
+                if (!isSignedIn()) {
+                    await initGoogleSignIn('googleSignInButton');
+                }
 
                 // Set up sign-out button
                 document.getElementById('signOutBtn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
Fixes bug where users appeared logged out when navigating back to the menu after playing a game.

## Root Cause
The `onAuthStateChanged` callback was being registered **after** `initAuth()` completed. When `initAuth()` restored the user from sessionStorage and called `notifyAuthStateChange()`, no callback was listening, so the UI never updated to show the signed-in state.

## Changes
1. **Fixed callback timing**: Moved `onAuthStateChanged()` registration to **before** `initAuth()` is called, ensuring the callback receives the notification when the user is restored
2. **Prevented unnecessary Google reinitialization**: Added conditional check `if (!isSignedIn())` before calling `initGoogleSignIn()` to avoid reinitializing Google's library when user is already authenticated

## Testing
- [x] Tested locally with Python HTTP server
- [x] Verified sign-in flow works correctly
- [x] Confirmed user remains signed in when navigating back from typing game
- [x] Verified sign-out still works correctly
- [x] No console errors

## Impact
- Users can now navigate between games and menu without losing authentication state
- sessionStorage-based auth persistence now works as intended
- No breaking changes to existing functionality

🤖 Ready for ChatGPT Codex review